### PR TITLE
41 hotfix problems when taking the inputcomponent in battle

### DIFF
--- a/src/main/Abstract/Utils/WorldUtlis.hpp
+++ b/src/main/Abstract/Utils/WorldUtlis.hpp
@@ -1,10 +1,10 @@
 #pragma once
-#include <algorithm>
 #include "Abstract/ECS/Archetype/ArchetypeManager.hpp"
 #include "Abstract/Overwordl/Components/PartOfLayerComponent.hpp"
 #include "Abstract/Overwordl/Components/Player_Component.hpp"
 #include "Abstract/Overwordl/Components/WorldComponent.hpp"
 #include "tileson.h"
+#include <algorithm>
 
 #include <magic_enum/magic_enum.hpp>
 class WorldUtils {
@@ -27,10 +27,8 @@ class WorldUtils {
 	{
 		WorldComponent *world = nullptr;
 
-		manager.view<WorldComponent>().each([&](auto id, auto &comp) {
-			world = &comp;
-		});
-		if(world == nullptr) {
+		manager.view<WorldComponent>().each([&](auto id, auto &comp) { world = &comp; });
+		if (world == nullptr) {
 			throw std::runtime_error("No world component found!");
 		}
 
@@ -45,11 +43,11 @@ class WorldUtils {
 		const auto &pComp = manager.getComponent<PartOfLayerComponent>(entity);
 		return isCurrentLayer(manager, pComp.layer, pComp.level);
 	}
-	template <typename ...T, typename Function>
-	static void viewInCurrentLayer(ArchetypeManager &manager,Function &&function)
+	template <typename... T, typename Function>
+	static void viewInCurrentLayer(ArchetypeManager &manager, Function &&function)
 	{
 
-		manager.view<T...>().each([&](auto &entity, T&... components) {
+		manager.view<T...>().each([&](auto &entity, T &...components) {
 			if (!isPartOfCurrentLayer(manager, entity)) {
 				return;
 			}
@@ -68,10 +66,9 @@ class WorldUtils {
 	static std::vector<EntityID> getPlayers(ArchetypeManager &manager)
 	{
 		std::vector<EntityID> result;
-		viewInCurrentLayer<PlayerComponent>(manager,[&](auto &entity, auto &component) { result.push_back(entity); });
+		viewInCurrentLayer<PlayerComponent>(manager, [&](auto &entity, auto &component) { result.push_back(entity); });
 		return result;
 	}
-
 
 	template <typename T>
 	static std::optional<std::reference_wrapper<T>> getPlayersComponent(ArchetypeManager &manager)
@@ -81,7 +78,7 @@ class WorldUtils {
 			throw std::runtime_error("No player found");
 		}
 		if (!manager.hasComponent<T>(player.value())) {
-			throw std::runtime_error("Player does not have the requested component");
+			return std::nullopt;
 		}
 		return std::ref(manager.getComponent<T>(player.value()));
 	}

--- a/src/main/Implementation/Overworld/InteractionSystem.cpp
+++ b/src/main/Implementation/Overworld/InteractionSystem.cpp
@@ -20,8 +20,8 @@ void InteractionSystem::update()
 	EntityID nearestInteractionEntity;
 	float smallestDistance = FLT_MAX;
 	bool candidateFound = false;
-	WorldUtils::viewInCurrentLayer<InteractionComponent, BoundIngBoxComponent>(manager,
-	    [&](auto &interactableEntity, InteractionComponent &component, BoundIngBoxComponent &bb) {
+	WorldUtils::viewInCurrentLayer<InteractionComponent, BoundIngBoxComponent>(
+	    manager, [&](auto &interactableEntity, InteractionComponent &component, BoundIngBoxComponent &bb) {
 		    component.inRange = false;
 
 		    auto &playerBB = manager.getComponent<BoundIngBoxComponent>(player);
@@ -51,6 +51,9 @@ void InteractionSystem::update()
 	}
 
 	if (component.trigger == INTERACTION_TRIGGER::byInteractionKey) {
+		if (!manager.hasComponent<InputComponent>(player)) {
+			return;
+		}
 		auto &inputComponent = manager.getComponent<InputComponent>(player);
 		component.inRange = true;
 		if (inputComponent.interact.justPressed) {

--- a/src/test/Abstract/Utils/WorldUtilsTest.cpp
+++ b/src/test/Abstract/Utils/WorldUtilsTest.cpp
@@ -1,0 +1,44 @@
+#include "Abstract/ECS/Archetype/ArchetypeManager.hpp"
+#include "Abstract/ECS/Test1.hpp"
+
+#include <Abstract/Overwordl/Components/InputComponent.hpp>
+#include <Abstract/Overwordl/Components/Player_Component.hpp>
+#include <Abstract/Utils/WorldUtlis.hpp>
+#include <Implementation/Components/BattleComponent.hpp>
+#include <Implementation/Components/StatsComponent.hpp>
+#include <gtest/gtest.h>
+
+TEST(WorldUtils, returnTrueWhenFindingPlayer)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	EXPECT_EQ(true, WorldUtils::getPlayer(manager).has_value());
+}
+
+// This is needed when the Battle takes away the inputComponent from the player, so that the system will ignore it
+TEST(WorldUtils, returnNullOptWhenPlayerDoesNotHaveComponent)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	EXPECT_EQ(false, WorldUtils::getPlayersComponent<InputComponent>(manager).has_value());
+}


### PR DESCRIPTION
Problems were:

- WorldUtils.getPlayerComponent() throw an error, when player did not have given component -> changed to nullopt
- InteractionSystem throw exception, because it tried to use InputComponent, which was taken from player -> checking with hasComponent() first