### PR TITLE
43 rework stats distributor

### DIFF
--- a/src/main/Abstract/Combat/Systems/CombatSystem.hpp
+++ b/src/main/Abstract/Combat/Systems/CombatSystem.hpp
@@ -34,7 +34,7 @@ class CombatSystem : public System {
 	sf::Clock clock;
 
 	void cleanUpBattle(EntityID battleManagerId, EntityID winningEntity, BattleState battleState);
-	static bool validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed);
+	static bool validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed, int numberOfHealsUsed);
 
   private:
 	float getDamageWithScaling(const StatsComponent &statsComponent, const WeaponComponent &weaponComponent,

--- a/src/main/Implementation/Components/BattleComponent.hpp
+++ b/src/main/Implementation/Components/BattleComponent.hpp
@@ -19,6 +19,7 @@ struct BattleComponent : Component<BattleComponent> {
 	BattleComponent() = default;
 	float AP{2};
 	int numberOfUltimateAttacksUsed{0};
+	int numberOfHealsUsed{0};
 	BattleAction selectedAction;
 	EntityID target;
 	bool isPlayerTeam;

--- a/src/main/Implementation/Components/StatsComponent.hpp
+++ b/src/main/Implementation/Components/StatsComponent.hpp
@@ -1,15 +1,23 @@
 #pragma once
 #include "Abstract/ECS/Component/Component.hpp"
 #include "Abstract/TILE_ENUMS.hpp"
+#include <array>
 #include <spdlog/spdlog.h>
 struct StatsComponent : Component<StatsComponent> {
   public:
-	StatsComponent() = default;
 	float experience{1};
 	int experienceLevel{1};
 	int numberOfFightsWon{0};
 	int health{100};
-	std::unordered_map<STATS, int> stats;
+	// 4 stats: strength, dexterity, faith, max_health
+	std::array<int, static_cast<size_t>(4)> stats{};
+
+	StatsComponent()
+	{
+		stats.fill(1);
+		stats[static_cast<size_t>(STATS::MAX_HEALTH)] = 100;
+	}
+
 	void readFromJson(tson::TiledClass &j) override
 	{
 
@@ -25,13 +33,7 @@ struct StatsComponent : Component<StatsComponent> {
 		addScalableStats(STATS::FAITH, faith);
 	}
 
-	void addScalableStats(STATS stat, int factor) { stats[stat] = factor; }
+	void addScalableStats(STATS stat, int factor) { stats[static_cast<size_t>(stat)] = factor; }
 
-	int getStat(STATS stat)
-	{
-		if (!stats.contains(stat)) {
-			return 50;
-		}
-		return stats[stat];
-	}
+	int getStat(STATS stat) const { return stats[static_cast<size_t>(stat)]; }
 };

--- a/src/main/Implementation/Components/WeaponComponent.hpp
+++ b/src/main/Implementation/Components/WeaponComponent.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "Abstract/ECS/Component/Component.hpp"
+#include "Abstract/Utils/WorldUtlis.hpp"
 #include "StatsComponent.hpp"
 #include <map>
-#include "Abstract/Utils/WorldUtlis.hpp"
 
 enum class WeaponType { MELEE, RANGE };
 
@@ -11,9 +11,9 @@ struct WeaponComponent : Component<WeaponComponent> {
 	WeaponType weaponType;
 	WEAPON_SCALING_FACTOR scalingFactor;
 	STATS scalingStat;
-	int lightAttackBaseDmg{1};
-	int heavyAttackBaseDmg{1};
-	int ultimateAttackBaseDmg{1};
+	int lightAttackBaseDmg{7};
+	int heavyAttackBaseDmg{18};
+	int ultimateAttackBaseDmg{35};
 
 	static float scaleFactorAsFloat(WEAPON_SCALING_FACTOR factor)
 	{
@@ -28,11 +28,11 @@ struct WeaponComponent : Component<WeaponComponent> {
 			return 0.0;
 		}
 	}
-	void readFromJson(tson::TiledClass &j)  override
+	void readFromJson(tson::TiledClass &j) override
 	{
-		weaponType = WorldUtils::getEnumValue<WeaponType>(j,"weapon_type");
-		scalingFactor = WorldUtils::getEnumValue<WEAPON_SCALING_FACTOR>(j,"scalingFactor");
-		scalingStat = WorldUtils::getEnumValue<STATS>(j,"scaleStat");
+		weaponType = WorldUtils::getEnumValue<WeaponType>(j, "weapon_type");
+		scalingFactor = WorldUtils::getEnumValue<WEAPON_SCALING_FACTOR>(j, "scalingFactor");
+		scalingStat = WorldUtils::getEnumValue<STATS>(j, "scaleStat");
 		lightAttackBaseDmg = j.get<int>("lightAttackBaseDmg");
 		heavyAttackBaseDmg = j.get<int>("heavyAttackBaseDmg");
 		ultimateAttackBaseDmg = j.get<int>("ultimateAttackBaseDmg");

--- a/src/main/Implementation/Systems/AISystem.cpp
+++ b/src/main/Implementation/Systems/AISystem.cpp
@@ -24,7 +24,8 @@ void AISystem::executeAILogic(EntityID aiId, std::vector<EntityID> participants)
 
 	aiBattle.target = target;
 
-	if (aiStats.health < 20 && aiBattle.AP >= CombatSystem::getActionCost(BattleAction::HEAL)) {
+	if (aiStats.health < 0.2 * aiStats.getStat(MAX_HEALTH) && aiBattle.numberOfHealsUsed < 2
+	    && aiBattle.AP >= CombatSystem::getActionCost(BattleAction::HEAL)) {
 		aiBattle.selectedAction = BattleAction::HEAL;
 	} else if (aiBattle.AP >= CombatSystem::getActionCost(BattleAction::HEAVY_ATTACK)) {
 		aiBattle.selectedAction = BattleAction::HEAVY_ATTACK;

--- a/src/main/Implementation/Systems/BattleInputSystem.cpp
+++ b/src/main/Implementation/Systems/BattleInputSystem.cpp
@@ -122,15 +122,7 @@ void BattleInputSystem::update()
 	}
 	auto &battle = manager.getComponent<BattleComponent>(playerId);
 	auto &stats = manager.getComponent<StatsComponent>(playerId);
-	auto &inv = manager.getComponent<InventoryComponent>(playerId);
-	std::vector<EntityID> healPositions;
-	for (auto &item : inv.inventory) {
-		bool IsHealItem = this->manager.hasComponent<ITEM_HEALSTATS_COMPONENT>(item);
-		if (IsHealItem) {
-			healPositions.push_back(item);
-		}
-	}
-	int numberOfHealPotions = healPositions.size();
+	int numberOfHealsUsed = battle.numberOfHealsUsed;
 	ui.setHUDVisible(true);
 	bool showMenu = battle.battleState == BattleState::WAITING_FOR_INPUT;
 	ui.setActionPanelVisible(showMenu);
@@ -140,15 +132,15 @@ void BattleInputSystem::update()
 
 		ui.getButton("BtnLight")
 		    ->setEnabled(CombatSystem::validateAction(BattleAction::LIGHT_ATTACK, battle.AP,
-		                                              battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
+		                                              battle.numberOfUltimateAttacksUsed, numberOfHealsUsed));
 		ui.getButton("BtnHeavy")
 		    ->setEnabled(CombatSystem::validateAction(BattleAction::HEAVY_ATTACK, battle.AP,
-		                                              battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
+		                                              battle.numberOfUltimateAttacksUsed, numberOfHealsUsed));
 		ui.getButton("BtnUltimate")
 		    ->setEnabled(CombatSystem::validateAction(BattleAction::ULTIMATE_ATTACK, battle.AP,
-		                                              battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
+		                                              battle.numberOfUltimateAttacksUsed, numberOfHealsUsed));
 		ui.getButton("BtnHeal")->setEnabled(CombatSystem::validateAction(
-		    BattleAction::HEAL, battle.AP, battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
+		    BattleAction::HEAL, battle.AP, battle.numberOfUltimateAttacksUsed, numberOfHealsUsed));
 		ui.getButton("BtnRest")->setEnabled(true);
 	}
 	auto bmcId = manager.getComponent<BattleComponent>(playerId).battleManagerId;

--- a/src/main/Implementation/Systems/CombatSystem.cpp
+++ b/src/main/Implementation/Systems/CombatSystem.cpp
@@ -110,6 +110,12 @@ void CombatSystem::executeBattleAction(EntityID attacker, EntityID defender, Bat
 		attackerBattle.battleState = BattleState::WAITING_FOR_INPUT;
 		return;
 	}
+
+	if (typeOfAction == BattleAction::HEAL and attackerBattle.numberOfHealsUsed >= 2) {
+		spdlog::get("combat")->warn("No heals left!");
+		attackerBattle.battleState = BattleState::WAITING_FOR_INPUT;
+		return;
+	}
 	switch (typeOfAction) {
 
 	case BattleAction::LIGHT_ATTACK: {
@@ -151,6 +157,7 @@ void CombatSystem::executeBattleAction(EntityID attacker, EntityID defender, Bat
 
 		auto &attackerStats = manager.getComponent<StatsComponent>(attacker);
 		this->takeHealAction(attacker, attackerStats.getStat(STATS::FAITH), attackerStats.getStat(STATS::MAX_HEALTH));
+		manager.getComponent<BattleComponent>(attacker).numberOfHealsUsed += 1;
 		break;
 	}
 	case BattleAction::REST: {
@@ -262,7 +269,7 @@ void CombatSystem::cleanUpBattle(EntityID battleManagerId, EntityID winningEntit
 		spdlog::get("combat")->info("You won the battle!");
 
 	} else if (battleState == BattleState::DEFEAT) {
-		// port away from enemy
+		// port away from enemy Fix for now
 		auto &trans = manager.getComponent<TransformComponent>(playerID.value());
 		trans.position = {0, 1};
 		spdlog::get("combat")->info("You lost the battle! Game over");
@@ -273,12 +280,14 @@ float CombatSystem::getDamageWithScaling(const StatsComponent &statsComponent, c
                                          BattleAction action)
 {
 	if (action == BattleAction::LIGHT_ATTACK) {
-		return weaponComponent.lightAttackBaseDmg + getMultiplicatorFromScalingFactor(statsComponent, weaponComponent);
+		return weaponComponent.lightAttackBaseDmg
+		       + getMultiplicatorFromScalingFactor(statsComponent, weaponComponent) * 1.0f;
 	} else if (action == BattleAction::HEAVY_ATTACK) {
-		return weaponComponent.heavyAttackBaseDmg + getMultiplicatorFromScalingFactor(statsComponent, weaponComponent);
+		return weaponComponent.heavyAttackBaseDmg
+		       + getMultiplicatorFromScalingFactor(statsComponent, weaponComponent) * 2.0f;
 	} else if (action == BattleAction::ULTIMATE_ATTACK) {
 		return weaponComponent.ultimateAttackBaseDmg
-		       + getMultiplicatorFromScalingFactor(statsComponent, weaponComponent);
+		       + getMultiplicatorFromScalingFactor(statsComponent, weaponComponent) * 3.0f;
 	}
 	throw std::runtime_error("Invalid weapon type");
 }
@@ -302,8 +311,7 @@ int CombatSystem::getActionCost(BattleAction action)
 	}
 }
 
-bool CombatSystem::validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed,
-                                  int numberOfHealthPotions)
+bool CombatSystem::validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed, int numberOfHealsUsed)
 {
 	int cost = getActionCost(action);
 	if (AP < cost) {
@@ -312,7 +320,7 @@ bool CombatSystem::validateAction(BattleAction action, int AP, int numberOfUltim
 	if (action == BattleAction::ULTIMATE_ATTACK && numberOfUltimateAttacksUsed >= 1) {
 		return false;
 	}
-	if (action == BattleAction::HEAL && numberOfHealthPotions <= 0) {
+	if (action == BattleAction::HEAL && numberOfHealsUsed >= 2) {
 		return false;
 	}
 	return true;

--- a/src/main/Implementation/Systems/StatsDistributorSystem.cpp
+++ b/src/main/Implementation/Systems/StatsDistributorSystem.cpp
@@ -51,18 +51,18 @@ void StatsDistributorSystem::showLevelUpMenu(EntityID playerId, BattleComponent 
 	data->mainLabel->setPosition(20, 20);
 	window->add(data->mainLabel);
 
-	auto addStatRow = [window, data](std::string name, STATS statsEnum, int yPos, int stepSize = 1) {
+	auto addStatRow = [window, data](std::string name, STATS statsEnum, int yPos, int currentVal, int stepSize = 1) {
 		data->extraStats[statsEnum] = 0;
-		auto label = tgui::Label::create(name + ": +0");
+		auto label = tgui::Label::create(name + " (" + std::to_string(currentVal) + "): +0");
 		label->setPosition(20, yPos);
 		window->add(label);
 
 		auto btnPlus = tgui::Button::create("+");
-		btnPlus->setPosition(150, yPos);
+		btnPlus->setPosition(200, yPos);
 		btnPlus->setSize(30, 30);
 
 		auto btnMinus = tgui::Button::create("-");
-		btnMinus->setPosition(190, yPos);
+		btnMinus->setPosition(240, yPos);
 		btnMinus->setSize(30, 30);
 
 		btnPlus->onPress([data, statsEnum, label, name, stepSize]() {
@@ -70,6 +70,7 @@ void StatsDistributorSystem::showLevelUpMenu(EntityID playerId, BattleComponent 
 				data->points--;
 				data->extraStats[statsEnum] += stepSize;
 				label->setText(name + ": +" + std::to_string(data->extraStats[statsEnum]));
+				data->mainLabel->getRenderer()->setTextColor(tgui::Color::Black);
 				data->mainLabel->setText("Points left: " + std::to_string(data->points));
 			}
 		});
@@ -79,6 +80,7 @@ void StatsDistributorSystem::showLevelUpMenu(EntityID playerId, BattleComponent 
 				data->points++;
 				data->extraStats[statsEnum] -= stepSize;
 				label->setText(name + ": +" + std::to_string(data->extraStats[statsEnum]));
+				data->mainLabel->getRenderer()->setTextColor(tgui::Color::Black);
 				data->mainLabel->setText("Points left: " + std::to_string(data->points));
 			}
 		});
@@ -86,15 +88,24 @@ void StatsDistributorSystem::showLevelUpMenu(EntityID playerId, BattleComponent 
 		window->add(btnPlus);
 		window->add(btnMinus);
 	};
-	addStatRow("Strength", STATS::STRENGTH, 60, 1);
-	addStatRow("Dexterity", STATS::DEXTERITY, 100, 1);
-	addStatRow("Faith", STATS::FAITH, 140, 1);
-	addStatRow("Max Health", STATS::MAX_HEALTH, 180, 10);
+	addStatRow("Strength", STATS::STRENGTH, 60, stats.getStat(STATS::STRENGTH), 1);
+	addStatRow("Dexterity", STATS::DEXTERITY, 100, stats.getStat(STATS::DEXTERITY), 1);
+	addStatRow("Faith", STATS::FAITH, 140, stats.getStat(STATS::FAITH), 1);
+	addStatRow("Max Health", STATS::MAX_HEALTH, 180, stats.getStat(STATS::MAX_HEALTH), 10);
 
 	auto confirmBtn = tgui::Button::create("Save and continue");
 	confirmBtn->setPosition(100, 220);
 
-	confirmBtn->onPress([this, &battle, &stats, data, window]() {
+	confirmBtn->onPress([this, playerId, data, window]() {
+		if (data->points > 0) {
+			data->mainLabel->getRenderer()->setTextColor(tgui::Color::Red);
+			data->mainLabel->setText("Please spend all points! Points left: " + std::to_string(data->points));
+			return;
+		}
+
+		auto &stats = manager.getComponent<StatsComponent>(playerId);
+		auto &battle = manager.getComponent<BattleComponent>(playerId);
+
 		for (const auto &[statEnum, extraPoints] : data->extraStats) {
 			if (extraPoints > 0) {
 				stats.stats[statEnum] = stats.getStat(statEnum) + extraPoints;

--- a/src/test/Implementation/Systems/CombatSystemTest.cpp
+++ b/src/test/Implementation/Systems/CombatSystemTest.cpp
@@ -79,7 +79,8 @@ TEST(CombatSystemTest, initialFightingSetupOneRoundLightAttack)
 	combatSystem.update();
 	EXPECT_EQ(BattleState::EXECUTING_ACTION, battleComponentP.battleState);
 	EXPECT_EQ(1, battleComponentP.AP);
-	EXPECT_EQ(34, statsComponentE.health);
+	// 92-(8+1*0.5*1)=83.5 -> (int) 83
+	EXPECT_EQ(83, statsComponentE.health);
 	combatSystem.update();
 	EXPECT_EQ(BattleState::CHECK_DEATH, battleComponentP.battleState);
 	combatSystem.update();
@@ -168,7 +169,8 @@ TEST(CombatSystemTest, initialFightingSetupOneRoundHeavyAttack)
 	combatSystem.update();
 	EXPECT_EQ(BattleState::EXECUTING_ACTION, battleComponentP.battleState);
 	EXPECT_EQ(0, battleComponentP.AP);
-	EXPECT_EQ(87, statsComponentE.health);
+	// 100-(12+1*2*0.5*2)=86
+	EXPECT_EQ(86, statsComponentE.health);
 	combatSystem.update();
 	EXPECT_EQ(BattleState::CHECK_DEATH, battleComponentP.battleState);
 	combatSystem.update();
@@ -254,7 +256,8 @@ TEST(CombatSystemTest, initialFightingSetupOneRoundUltimateAttack)
 	combatSystem.update();
 	EXPECT_EQ(BattleState::EXECUTING_ACTION, battleComponentP.battleState);
 	EXPECT_EQ(2, battleComponentP.AP);
-	EXPECT_EQ(67, statsComponentE.health);
+	// 100-(20+1*0.25*3)=79.25 -> (int) 79
+	EXPECT_EQ(79, statsComponentE.health);
 	EXPECT_EQ(1, battleComponentP.numberOfUltimateAttacksUsed);
 	combatSystem.update();
 	EXPECT_EQ(BattleState::CHECK_DEATH, battleComponentP.battleState);
@@ -434,6 +437,7 @@ TEST(CombatSystemTest, initialFightingSetupOneRoundHealWithNonFullLife)
 	EXPECT_EQ(0, battleComponentP.AP);
 	EXPECT_EQ(20, statsComponentE.health);
 	EXPECT_EQ(101, statsComponentP.health);
+	EXPECT_EQ(1, battleComponentP.numberOfHealsUsed);
 
 	combatSystem.update();
 	EXPECT_EQ(BattleState::CHECK_DEATH, battleComponentP.battleState);


### PR DESCRIPTION
Closing #43 

Changes: 

- The stats distribution menu stays open until all points are spent
- In stats distribution menu, show the current level of the ability
- Healing is now restrained to 2 times per fight
- Stats are no longer a map, but a array instead
- Set standard ability values to 1 and maxHealth to 100
- Standard damage (fists) is now 7, 18, 35 instead of 1, 1, 1