### PR TITLE
40 enable fighting with more than one enemy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = true
+insert_final_newline = false
 trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 8

--- a/src/main/Abstract/Combat/Components/CombatGodMode.hpp
+++ b/src/main/Abstract/Combat/Components/CombatGodMode.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "Abstract/ECS/Component/Component.hpp"
+
+struct CombatGodMode : public Component<CombatGodMode> {
+	CombatGodMode() = default;
+	virtual void readFromJson(tson::TiledClass &j) override {};
+};

--- a/src/main/Abstract/Combat/Components/DeathComponent.hpp
+++ b/src/main/Abstract/Combat/Components/DeathComponent.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "Abstract/ECS/Component/Component.hpp"
+
+struct DeathComponent : public Component<DeathComponent> {
+	DeathComponent() = default;
+	virtual void readFromJson(tson::TiledClass &j) override {};
+};

--- a/src/main/Abstract/Combat/Components/DeathComponent.hpp
+++ b/src/main/Abstract/Combat/Components/DeathComponent.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include "Abstract/ECS/Component/Component.hpp"
-
+#include "Abstract/Overwordl/Components/SpriteComponent.hpp"
 struct DeathComponent : public Component<DeathComponent> {
 	DeathComponent() = default;
 	virtual void readFromJson(tson::TiledClass &j) override {};
+	TileInfo graveTile;
+	std::string graveTilesetPath;
 };

--- a/src/main/Abstract/Combat/Systems/AISystem.hpp
+++ b/src/main/Abstract/Combat/Systems/AISystem.hpp
@@ -8,6 +8,7 @@
 class AISystem : public System {
   public:
 	AISystem(ArchetypeManager &manager);
+	std::optional<EntityID> selectTarget(EntityID aiId, const std::vector<EntityID> participants);
 	void executeAILogic(EntityID aiId, std::vector<EntityID> participants);
 	void update();
 };

--- a/src/main/Abstract/Combat/Systems/BattleInputSystem.hpp
+++ b/src/main/Abstract/Combat/Systems/BattleInputSystem.hpp
@@ -21,5 +21,6 @@ class BattleInputSystem : public System {
 
 	void update() override;
 	void init();
-	std::vector<EntityID> getTargetsInBattle(const EntityID playerId, const EntityID managerId);
+	static std::vector<EntityID> getTargetsInBattle(const EntityID playerId, const EntityID managerId,
+	                                                ArchetypeManager &manager);
 };

--- a/src/main/Abstract/Combat/Systems/BattleInputSystem.hpp
+++ b/src/main/Abstract/Combat/Systems/BattleInputSystem.hpp
@@ -11,11 +11,15 @@ class BattleInputSystem : public System {
 	BattleUI ui;
 	void connectCallbacks();
 	sf::RenderWindow &window;
+	int currentTargetIndex = 0;
+	bool rightKeyWasPressed = false;
+	bool leftKeyWasPressed = false;
+	bool enterKeyWasPressed = false;
 
   public:
 	BattleInputSystem(ArchetypeManager &manager, tgui::Gui &gui, sf::RenderWindow &window);
 
 	void update() override;
 	void init();
-	EntityID selectTarget(std::vector<EntityID> participants, EntityID playerId);
+	std::vector<EntityID> getTargetsInBattle(const EntityID playerId, const EntityID managerId);
 };

--- a/src/main/Abstract/Combat/Systems/CombatSystem.hpp
+++ b/src/main/Abstract/Combat/Systems/CombatSystem.hpp
@@ -33,7 +33,7 @@ class CombatSystem : public System {
 	sf::Clock clock;
 
 	void cleanUpBattle(EntityID battleManagerId, EntityID winningEntity, BattleState battleState);
-	static bool validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed, int numberOfHealthPotions);
+	static bool validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed);
 
   private:
 	float getDamageWithScaling(const StatsComponent &statsComponent, const WeaponComponent &weaponComponent,

--- a/src/main/Abstract/Combat/Systems/CombatSystem.hpp
+++ b/src/main/Abstract/Combat/Systems/CombatSystem.hpp
@@ -6,6 +6,7 @@
 #include "Implementation/Components/BattleComponent.hpp"
 #include "Implementation/Components/StatsComponent.hpp"
 #include "Implementation/Components/WeaponComponent.hpp"
+#include <Abstract/Combat/Components/BattleManagerComponent.hpp>
 #include <SFML/Graphics.hpp>
 
 class CombatSystem : public System {
@@ -24,9 +25,9 @@ class CombatSystem : public System {
 
 	BattleState checkDeathCondition(EntityID defender, EntityID attacker);
 
-	void passTurn(EntityID &currentEntity, int currentTurnIndex, const std::vector<EntityID> participants);
+	void passTurn(EntityID &currentEntity, BattleManagerComponent &bmc);
 
-	EntityID getAttacker(int currentTurnIndex, const std::vector<EntityID> participants);
+	EntityID getAttacker(BattleManagerComponent &bmc);
 
 	static int getActionCost(BattleAction action);
 

--- a/src/main/Abstract/Combat/Systems/EnemyHealthBarSystem.hpp
+++ b/src/main/Abstract/Combat/Systems/EnemyHealthBarSystem.hpp
@@ -15,6 +15,6 @@ class EnemyHealthBarSystem : public System {
 	sf::RenderWindow &window;
 	std::unordered_map<EntityID, tgui::ProgressBar::Ptr> enemyBars;
 	void createEnemyBar(EntityID id);
-	void updateEnemyBar(EntityID id, float hp, float maxHp, sf::Vector2f screenPos);
+	void updateEnemyBar(EntityID id, float hp, float maxHp, sf::Vector2f screenPos, bool isHoveringTarget);
 	void clearAllBars();
 };

--- a/src/main/Abstract/Overwordl/SwitchBattleModeSystem.hpp
+++ b/src/main/Abstract/Overwordl/SwitchBattleModeSystem.hpp
@@ -2,9 +2,18 @@
 
 #pragma once
 #include "Abstract/ECS/System/System.hpp"
+#include <SFML/Graphics/RenderWindow.hpp>
 
 struct SwitchBattleModeSystem : System {
 
 	SwitchBattleModeSystem(ArchetypeManager &manager);
 	void update() override;
+	[[nodiscard]] std::vector<EntityID> getEnemiesInRatio(const sf::Vector2f center, float radius);
+	void prepareForBattle(const std::vector<EntityID> &participants, EntityID playerId);
+	static float getSquaredDistance(const sf::Vector2f &a, const sf::Vector2f &b)
+	{
+		float dx = a.x - b.x;
+		float dy = a.y - b.y;
+		return (dx * dx) + (dy * dy);
+	}
 };

--- a/src/main/Abstract/Overwordl/SwitchBattleModeSystem.hpp
+++ b/src/main/Abstract/Overwordl/SwitchBattleModeSystem.hpp
@@ -8,7 +8,7 @@ struct SwitchBattleModeSystem : System {
 
 	SwitchBattleModeSystem(ArchetypeManager &manager);
 	void update() override;
-	[[nodiscard]] std::vector<EntityID> getEnemiesInRatio(const sf::Vector2f center, float radius);
+	[[nodiscard]] std::vector<EntityID> getEnemiesInRatio(const sf::Vector2f center, float radius, EntityID playerId);
 	void prepareForBattle(const std::vector<EntityID> &participants, EntityID playerId);
 	static float getSquaredDistance(const sf::Vector2f &a, const sf::Vector2f &b)
 	{

--- a/src/main/Abstract/Utils/GraveConfig.hpp
+++ b/src/main/Abstract/Utils/GraveConfig.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include "Abstract/Overwordl/Components/SpriteComponent.hpp"
+#include <string>
+struct GraveConfig {
+	static inline TileInfo defaultTile = {16,160,16,16};
+	static inline std::string tilesetPath = SPRITE_SHEET_PATH;
+};

--- a/src/main/Implementation/Components/BattleComponent.hpp
+++ b/src/main/Implementation/Components/BattleComponent.hpp
@@ -9,6 +9,7 @@ enum class BattleState {
 	EXECUTING_ACTION,
 	CHECK_DEATH,
 	WAITING_FOR_INPUT,
+	SELECTING_TARGET,
 	NEXT_ROUND,
 	VICTORY,
 	DEFEAT,
@@ -27,6 +28,6 @@ struct BattleComponent : Component<BattleComponent> {
 	float actionTimer = 0.0f;
 	float actionDelay = 0.0f;
 	EntityID battleManagerId;
-
+	std::optional<EntityID> hoveringTarget = std::nullopt;
 	void readFromJson(tson::TiledClass &j) override {}
 };

--- a/src/main/Implementation/Components/StatsComponent.hpp
+++ b/src/main/Implementation/Components/StatsComponent.hpp
@@ -30,6 +30,9 @@ struct StatsComponent : Component<StatsComponent> {
 	int getStat(STATS stat)
 	{
 		if (!stats.contains(stat)) {
+			if (stat == STATS::MAX_HEALTH) {
+				return 100;
+			}
 			return 50;
 		}
 		return stats[stat];

--- a/src/main/Implementation/Overworld/RenderSystem.cpp
+++ b/src/main/Implementation/Overworld/RenderSystem.cpp
@@ -7,14 +7,15 @@
 #include "Abstract/Overwordl/Components/TransformComponent.hpp"
 #include "Abstract/Overwordl/Components/WorldComponent.hpp"
 #include "Abstract/Utils/WorldUtlis.hpp"
+#include <Abstract/Combat/Components/DeathComponent.hpp>
+#include <SFML/Graphics/RectangleShape.hpp>
 
 RenderSystem::RenderSystem(ArchetypeManager &manager, sf::RenderWindow &window) : System(manager), window(window) {};
 
-void render(TransformComponent &tcomp, sf::RenderWindow &window,
-            SpriteComponent &scomp)
+void render(TransformComponent &tcomp, sf::RenderWindow &window, SpriteComponent &scomp)
 {
 
-	sf::Sprite sp = AssetManager::getInstance().getSpriteAt(scomp);	
+	sf::Sprite sp = AssetManager::getInstance().getSpriteAt(scomp);
 	sp.setPosition(tcomp.position);
 	sp.setScale(tcomp.scale);
 	sp.setRotation(tcomp.rotation);
@@ -22,17 +23,38 @@ void render(TransformComponent &tcomp, sf::RenderWindow &window,
 }
 void RenderSystem::update()
 {
-	WorldUtils::viewInCurrentLayer<RenderComponent, TransformComponent, SpriteComponent>(manager,
-		[&](const EntityID &id, RenderComponent &comp, TransformComponent &tcomp, SpriteComponent &scomp) {
-			if (comp.z_layer == 0) {
-				render(tcomp, window, scomp);
-			}
-		});
+	auto renderLogic = [&](const EntityID &id, RenderComponent &comp, TransformComponent &tcomp,
+	                       SpriteComponent &scomp) {
+		if (manager.hasComponent<DeathComponent>(id)) {
+			/*
+			// DEBUG
+			sf::RectangleShape debugBox;
+			debugBox.setSize({(float)scomp.tileInfo.width, (float)scomp.tileInfo.height});
+			debugBox.setPosition(tcomp.position);
+			debugBox.setFillColor(sf::Color::Red);
+			window.draw(debugBox);
+			*/
+			auto &deathC = manager.getComponent<DeathComponent>(id);
+			SpriteComponent graveVisuals;
+			graveVisuals.tileInfo = deathC.graveTile;
+			graveVisuals.tilesetPath = deathC.graveTilesetPath;
+			render(tcomp, window, graveVisuals);
+		} else {
+			render(tcomp, window, scomp);
+		}
+	};
 
-	WorldUtils::viewInCurrentLayer<RenderComponent, TransformComponent, SpriteComponent>(manager,
-		[&](const EntityID &id, RenderComponent &comp, TransformComponent &tcomp, SpriteComponent &scomp) {
-			if (comp.z_layer) {
-				render(tcomp, window, scomp);
-			}
-		});
+	WorldUtils::viewInCurrentLayer<RenderComponent, TransformComponent, SpriteComponent>(
+	    manager, [&](const EntityID &id, RenderComponent &comp, TransformComponent &tcomp, SpriteComponent &scomp) {
+		    if (comp.z_layer == 0) {
+			    renderLogic(id, comp, tcomp, scomp);
+		    }
+	    });
+
+	WorldUtils::viewInCurrentLayer<RenderComponent, TransformComponent, SpriteComponent>(
+	    manager, [&](const EntityID &id, RenderComponent &comp, TransformComponent &tcomp, SpriteComponent &scomp) {
+		    if (comp.z_layer) {
+			    renderLogic(id, comp, tcomp, scomp);
+		    }
+	    });
 }

--- a/src/main/Implementation/Overworld/SwitchBattleModeSystem.cpp
+++ b/src/main/Implementation/Overworld/SwitchBattleModeSystem.cpp
@@ -43,7 +43,8 @@ void SwitchBattleModeSystem::update()
 		return;
 	std::vector<EntityID> participantsList;
 	participantsList.push_back(player);
-	auto enemyList = getEnemiesInRatio(manager.getComponent<TransformComponent>(initialEnemyId).position, 50.0f);
+	auto enemyList =
+	    getEnemiesInRatio(manager.getComponent<TransformComponent>(initialEnemyId).position, 50.0f, player);
 	participantsList.insert(participantsList.end(), enemyList.begin(), enemyList.end());
 
 	EntityID bManager = this->manager.createEntity<BattleManagerComponent, PartOfLayerComponent>();
@@ -87,11 +88,15 @@ void SwitchBattleModeSystem::update()
 	spdlog::get("combat")->info("Switched to battle mode");
 }
 
-std::vector<EntityID> SwitchBattleModeSystem::getEnemiesInRatio(const sf::Vector2f center, float radius)
+std::vector<EntityID> SwitchBattleModeSystem::getEnemiesInRatio(const sf::Vector2f center, float radius,
+                                                                EntityID playerId)
 {
 	std::vector<EntityID> enemiesIdList;
 	this->manager.view<InventoryComponent, TransformComponent>().each(
 	    [&](auto entityId, auto &eqComponent, auto &transformComponent) {
+		    if (entityId == playerId) {
+			    return;
+		    }
 		    if (!WorldUtils::isPartOfCurrentLayer(this->manager, entityId)) {
 			    return;
 		    }

--- a/src/main/Implementation/Overworld/SwitchBattleModeSystem.cpp
+++ b/src/main/Implementation/Overworld/SwitchBattleModeSystem.cpp
@@ -10,6 +10,8 @@
 #include <Abstract/Overwordl/Components/InputComponent.hpp>
 #include <Abstract/Overwordl/Components/InventoryComponent.hpp>
 #include <Abstract/Overwordl/Components/MovementComponent.hpp>
+#include <Abstract/Overwordl/Components/START_EQUIPMENT_COMPONENT.hpp>
+#include <Abstract/Overwordl/Components/TransformComponent.hpp>
 #include <spdlog/spdlog.h>
 
 SwitchBattleModeSystem::SwitchBattleModeSystem(ArchetypeManager &manager) : System(manager) {}
@@ -34,18 +36,17 @@ void SwitchBattleModeSystem::update()
 		return;
 	}
 	EntityID player = WorldUtils::getPlayer(manager).value();
-	EntityID enemyId = interActorId.value();
+	EntityID initialEnemyId = interActorId.value();
 	icomp->isActive = false;
 
 	if (manager.hasComponent<BattleComponent>(player))
 		return;
+	std::vector<EntityID> participantsList;
+	participantsList.push_back(player);
+	auto enemyList = getEnemiesInRatio(manager.getComponent<TransformComponent>(initialEnemyId).position, 50.0f);
+	participantsList.insert(participantsList.end(), enemyList.begin(), enemyList.end());
 
-	this->manager.removeComponentFromEntity<InputComponent>(player);
-	this->manager.addComponentToEntity<BattleComponent>(player);
-	this->manager.addComponentToEntity<BattleComponent>(enemyId);
-
-	EntityID bManager =
-	    this->manager.createEntity<BattleManagerComponent, PartOfLayerComponent>(EntityTag::BATTLEMANAGER);
+	EntityID bManager = this->manager.createEntity<BattleManagerComponent, PartOfLayerComponent>();
 	WorldComponent *world = WorldUtils::getWorld(manager);
 	if (world == nullptr) {
 		return;
@@ -60,33 +61,54 @@ void SwitchBattleModeSystem::update()
 			return;
 		}
 		battleManagerId = entity;
-		component.participants = {player, enemyId};
+		component.participants = {player, initialEnemyId};
 		found = true;
 	});
 
-	this->manager.getComponent<BattleManagerComponent>(bManager).participants.push_back(player);
-	this->manager.getComponent<BattleManagerComponent>(bManager).participants.push_back(enemyId);
+	prepareForBattle(participantsList, player);
+	this->manager.getComponent<BattleManagerComponent>(bManager).participants = participantsList;
 
-	this->manager.getComponent<BattleComponent>(player).battleManagerId = battleManagerId;
-	this->manager.getComponent<BattleComponent>(enemyId).battleManagerId = battleManagerId;
-
-	auto inventoryP = this->manager.getComponent<InventoryComponent>(player);
-	auto inventoryE = this->manager.getComponent<InventoryComponent>(enemyId);
-
-	auto weaponP = inventoryP.getEquippedItem(ITEM_TYPE::WEAPON);
-	auto weaponE = inventoryE.getEquippedItem(ITEM_TYPE::WEAPON);
-
-	for (auto &entity : {player, enemyId}) {
-		if (!this->manager.hasComponent<BattleComponent>(entity)) {
+	for (const auto &participant : participantsList) {
+		this->manager.getComponent<BattleComponent>(participant).battleManagerId = battleManagerId;
+		auto inventory = this->manager.getComponent<InventoryComponent>(participant);
+		auto weapon = inventory.getEquippedItem(ITEM_TYPE::WEAPON);
+		if (!this->manager.hasComponent<BattleComponent>(participant)) {
 			throw std::runtime_error("Batteling entity does not have a battle component");
 		}
-		if (!this->manager.hasComponent<StatsComponent>(entity)) {
+		if (!this->manager.hasComponent<StatsComponent>(participant)) {
 			throw std::runtime_error("Batteling entity does not have a stat component");
 		}
-		std::cout << "Health for entity " << entity.getId() << ": " << this->manager.getComponent<StatsComponent>(entity).health << std::endl;
-		if (!this->manager.hasComponent<InventoryComponent>(entity)) {
+		std::cout << "Health for entity " << participant.getId() << ": "
+		          << this->manager.getComponent<StatsComponent>(participant).health << std::endl;
+		if (!this->manager.hasComponent<InventoryComponent>(participant)) {
 			throw std::runtime_error("Batteling entity does not have a inventory component");
 		}
 	}
 	spdlog::get("combat")->info("Switched to battle mode");
+}
+
+std::vector<EntityID> SwitchBattleModeSystem::getEnemiesInRatio(const sf::Vector2f center, float radius)
+{
+	std::vector<EntityID> enemiesIdList;
+	this->manager.view<InventoryComponent, TransformComponent>().each(
+	    [&](auto entityId, auto &eqComponent, auto &transformComponent) {
+		    if (!WorldUtils::isPartOfCurrentLayer(this->manager, entityId)) {
+			    return;
+		    }
+		    if (SwitchBattleModeSystem::getSquaredDistance(center, transformComponent.position) <= radius * radius) {
+			    enemiesIdList.push_back(entityId);
+		    }
+	    });
+	spdlog::get("combat")->info("Found {} enemies in the action radius", enemiesIdList.size());
+	return enemiesIdList;
+}
+
+void SwitchBattleModeSystem::prepareForBattle(const std::vector<EntityID> &participants, EntityID playerId)
+{
+	for (const auto &participant : participants) {
+		if (participant == playerId) {
+			this->manager.removeComponentFromEntity<InputComponent>(participant);
+		}
+		this->manager.addComponentToEntity<BattleComponent>(participant);
+	}
 }

--- a/src/main/Implementation/Systems/AISystem.cpp
+++ b/src/main/Implementation/Systems/AISystem.cpp
@@ -8,21 +8,30 @@
 #include "Implementation/Components/BattleComponent.hpp"
 
 #include "Implementation/Components/StatsComponent.hpp"
+#include <Abstract/Combat/Components/DeathComponent.hpp>
 
 AISystem::AISystem(ArchetypeManager &manager) : System(manager) {};
+
+std::optional<EntityID> AISystem::selectTarget(EntityID aiId, const std::vector<EntityID> participants)
+{
+	for (EntityID p : participants) {
+		// TODO: also check for the companions of the player and then select between the targets
+		if (aiId != p && manager.hasComponent<PlayerComponent>(p) && !manager.hasComponent<DeathComponent>(p)) {
+			return p;
+		}
+	}
+	return std::nullopt;
+}
 void AISystem::executeAILogic(EntityID aiId, std::vector<EntityID> participants)
 {
 	BattleComponent &aiBattle = manager.getComponent<BattleComponent>(aiId);
 	StatsComponent &aiStats = manager.getComponent<StatsComponent>(aiId);
-	EntityID target;
-	for (EntityID p : participants) {
-		if (aiId != p) {
-			target = p;
-			break;
-		}
-	}
 
-	aiBattle.target = target;
+	auto targetOpt = selectTarget(aiId, participants);
+	if (!targetOpt.has_value()) {
+		throw std::runtime_error("No valid target found for AI entity " + std::to_string(aiId.getId()));
+	}
+	aiBattle.target = targetOpt.value();
 
 	if (aiStats.health < 20 && aiBattle.AP >= CombatSystem::getActionCost(BattleAction::HEAL)) {
 		aiBattle.selectedAction = BattleAction::HEAL;

--- a/src/main/Implementation/Systems/BattleInputSystem.cpp
+++ b/src/main/Implementation/Systems/BattleInputSystem.cpp
@@ -136,10 +136,17 @@ void BattleInputSystem::update()
 		    CombatSystem::validateAction(BattleAction::HEAL, battle.AP, battle.numberOfUltimateAttacksUsed));
 		ui.getButton("BtnRest")->setEnabled(true);
 	} else if (showTargetMenu) {
-		auto validTargets =
-		    getTargetsInBattle(playerId, manager.getComponent<BattleComponent>(playerId).battleManagerId);
+		auto validTargets = getTargetsInBattle(
+		    playerId, manager.getComponent<BattleComponent>(playerId).battleManagerId, this->manager);
 		if (validTargets.empty()) {
 			throw std::runtime_error("No valid targets in battle for player");
+		}
+		auto selectedAction = battle.selectedAction;
+		if (selectedAction == BattleAction::HEAL || selectedAction == BattleAction::REST) {
+			battle.battleState = BattleState::SELECTED_ACTION;
+			battle.hoveringTarget = std::nullopt;
+			ui.setActionPanelVisible(false);
+			return;
 		}
 		std::sort(validTargets.begin(), validTargets.end(), [this](const EntityID a, const EntityID b) {
 			auto transformA = manager.getComponent<TransformComponent>(a);
@@ -177,7 +184,8 @@ void BattleInputSystem::update()
 	}
 }
 
-std::vector<EntityID> BattleInputSystem::getTargetsInBattle(const EntityID playerId, const EntityID battleMangerId)
+std::vector<EntityID> BattleInputSystem::getTargetsInBattle(const EntityID playerId, const EntityID battleMangerId,
+                                                            ArchetypeManager &manager)
 {
 	const auto &bmc = manager.getComponent<BattleManagerComponent>(battleMangerId).participants;
 	std::vector<EntityID> targets;

--- a/src/main/Implementation/Systems/BattleInputSystem.cpp
+++ b/src/main/Implementation/Systems/BattleInputSystem.cpp
@@ -5,9 +5,11 @@
 #include "Abstract/Overwordl/Components/ItemHealstatsComponent.hpp"
 #include "Abstract/Overwordl/Components/Player_Component.hpp"
 #include "Implementation/Components/BattleComponent.hpp"
+#include <Abstract/Combat/Components/DeathComponent.hpp>
 #include <Abstract/Overwordl/Components/TransformComponent.hpp>
 #include <Abstract/TILE_ENUMS.hpp>
 #include <Abstract/Utils/WorldUtlis.hpp>
+#include <SFML/Window/Keyboard.hpp>
 #include <TGUI/Backend/SFML-Graphics.hpp>
 #include <TGUI/TGUI.hpp>
 BattleInputSystem::BattleInputSystem(ArchetypeManager &manager, tgui::Gui &gui, sf::RenderWindow &window)
@@ -40,9 +42,7 @@ void BattleInputSystem::connectCallbacks()
 		if (manager.hasComponent<BattleComponent>(playerId)) {
 			auto &b = manager.getComponent<BattleComponent>(playerId);
 			b.selectedAction = BattleAction::LIGHT_ATTACK;
-			b.target =
-			    selectTarget(manager.getComponent<BattleManagerComponent>(b.battleManagerId).participants, playerId);
-			b.battleState = BattleState::SELECTED_ACTION;
+			b.battleState = BattleState::SELECTING_TARGET;
 		}
 	});
 	ui.getButton("BtnHeavy")->onPress([this]() {
@@ -54,9 +54,7 @@ void BattleInputSystem::connectCallbacks()
 		if (manager.hasComponent<BattleComponent>(playerId)) {
 			auto &b = manager.getComponent<BattleComponent>(playerId);
 			b.selectedAction = BattleAction::HEAVY_ATTACK;
-			b.target =
-			    selectTarget(manager.getComponent<BattleManagerComponent>(b.battleManagerId).participants, playerId);
-			b.battleState = BattleState::SELECTED_ACTION;
+			b.battleState = BattleState::SELECTING_TARGET;
 		}
 	});
 	ui.getButton("BtnUltimate")->onPress([this]() {
@@ -68,9 +66,7 @@ void BattleInputSystem::connectCallbacks()
 		if (manager.hasComponent<BattleComponent>(playerId)) {
 			auto &b = manager.getComponent<BattleComponent>(playerId);
 			b.selectedAction = BattleAction::ULTIMATE_ATTACK;
-			b.target =
-			    selectTarget(manager.getComponent<BattleManagerComponent>(b.battleManagerId).participants, playerId);
-			b.battleState = BattleState::SELECTED_ACTION;
+			b.battleState = BattleState::SELECTING_TARGET;
 		}
 	});
 	ui.getButton("BtnHeal")->onPress([this]() {
@@ -82,9 +78,7 @@ void BattleInputSystem::connectCallbacks()
 		if (manager.hasComponent<BattleComponent>(playerId)) {
 			auto &b = manager.getComponent<BattleComponent>(playerId);
 			b.selectedAction = BattleAction::HEAL;
-			b.target =
-			    selectTarget(manager.getComponent<BattleManagerComponent>(b.battleManagerId).participants, playerId);
-			b.battleState = BattleState::SELECTED_ACTION;
+			b.battleState = BattleState::SELECTING_TARGET;
 		}
 	});
 	ui.getButton("BtnRest")->onPress([this]() {
@@ -96,9 +90,7 @@ void BattleInputSystem::connectCallbacks()
 		if (manager.hasComponent<BattleComponent>(playerId)) {
 			auto &b = manager.getComponent<BattleComponent>(playerId);
 			b.selectedAction = BattleAction::REST;
-			b.target =
-			    selectTarget(manager.getComponent<BattleManagerComponent>(b.battleManagerId).participants, playerId);
-			b.battleState = BattleState::SELECTED_ACTION;
+			b.battleState = BattleState::SELECTING_TARGET;
 		}
 	});
 }
@@ -122,45 +114,78 @@ void BattleInputSystem::update()
 	}
 	auto &battle = manager.getComponent<BattleComponent>(playerId);
 	auto &stats = manager.getComponent<StatsComponent>(playerId);
-	auto &inv = manager.getComponent<InventoryComponent>(playerId);
-	std::vector<EntityID> healPositions;
-	for (auto &item : inv.inventory) {
-		bool IsHealItem = this->manager.hasComponent<ITEM_HEALSTATS_COMPONENT>(item);
-		if (IsHealItem) {
-			healPositions.push_back(item);
-		}
-	}
-	int numberOfHealPotions = healPositions.size();
+
 	ui.setHUDVisible(true);
 	bool showMenu = battle.battleState == BattleState::WAITING_FOR_INPUT;
 	ui.setActionPanelVisible(showMenu);
 
+	bool showTargetMenu = battle.battleState == BattleState::SELECTING_TARGET;
 	if (showMenu) {
 		ui.updateStats(stats.health, stats.getStat(MAX_HEALTH), battle.AP);
 
 		ui.getButton("BtnLight")
 		    ->setEnabled(CombatSystem::validateAction(BattleAction::LIGHT_ATTACK, battle.AP,
-		                                              battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
+		                                              battle.numberOfUltimateAttacksUsed));
 		ui.getButton("BtnHeavy")
 		    ->setEnabled(CombatSystem::validateAction(BattleAction::HEAVY_ATTACK, battle.AP,
-		                                              battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
+		                                              battle.numberOfUltimateAttacksUsed));
 		ui.getButton("BtnUltimate")
 		    ->setEnabled(CombatSystem::validateAction(BattleAction::ULTIMATE_ATTACK, battle.AP,
-		                                              battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
-		ui.getButton("BtnHeal")->setEnabled(CombatSystem::validateAction(
-		    BattleAction::HEAL, battle.AP, battle.numberOfUltimateAttacksUsed, numberOfHealPotions));
+		                                              battle.numberOfUltimateAttacksUsed));
+		ui.getButton("BtnHeal")->setEnabled(
+		    CombatSystem::validateAction(BattleAction::HEAL, battle.AP, battle.numberOfUltimateAttacksUsed));
 		ui.getButton("BtnRest")->setEnabled(true);
+	} else if (showTargetMenu) {
+		auto validTargets =
+		    getTargetsInBattle(playerId, manager.getComponent<BattleComponent>(playerId).battleManagerId);
+		if (validTargets.empty()) {
+			throw std::runtime_error("No valid targets in battle for player");
+		}
+		std::sort(validTargets.begin(), validTargets.end(), [this](const EntityID a, const EntityID b) {
+			auto transformA = manager.getComponent<TransformComponent>(a);
+			auto transformB = manager.getComponent<TransformComponent>(b);
+			return transformA.position.x < transformB.position.x;
+		});
+		if (currentTargetIndex >= validTargets.size()) {
+			currentTargetIndex = 0;
+		}
+		if (!battle.hoveringTarget.has_value()) {
+			battle.hoveringTarget = validTargets[currentTargetIndex];
+		}
+		bool rightPressed = sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Right);
+		if (rightPressed && !rightKeyWasPressed) {
+			currentTargetIndex = (currentTargetIndex + 1) % validTargets.size();
+			battle.hoveringTarget = validTargets[currentTargetIndex];
+		}
+		rightKeyWasPressed = rightPressed;
+
+		bool leftPressed = sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Left);
+		if (leftPressed && !leftKeyWasPressed) {
+			currentTargetIndex = (currentTargetIndex == 0) ? (validTargets.size() - 1) : (currentTargetIndex - 1);
+			battle.hoveringTarget = validTargets[currentTargetIndex];
+		}
+		leftKeyWasPressed = leftPressed;
+
+		bool enterPressed = sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Enter);
+		if (enterPressed && !enterKeyWasPressed) {
+			battle.target = validTargets[currentTargetIndex];
+			battle.battleState = BattleState::SELECTED_ACTION;
+			battle.hoveringTarget = std::nullopt;
+			ui.setActionPanelVisible(false);
+		}
+		enterKeyWasPressed = enterPressed;
 	}
-	auto bmcId = manager.getComponent<BattleComponent>(playerId).battleManagerId;
-	auto &bmc = manager.getComponent<BattleManagerComponent>(bmcId);
 }
 
-EntityID BattleInputSystem::selectTarget(std::vector<EntityID> participants, EntityID playerId)
+std::vector<EntityID> BattleInputSystem::getTargetsInBattle(const EntityID playerId, const EntityID battleMangerId)
 {
-	for (EntityID entity : participants) {
-		if (entity != playerId) {
-			return entity;
+	const auto &bmc = manager.getComponent<BattleManagerComponent>(battleMangerId).participants;
+	std::vector<EntityID> targets;
+	for (EntityID entity : bmc) {
+		// TODO: add logic for not attacking companions later
+		if (entity != playerId && !manager.hasComponent<DeathComponent>(entity)) {
+			targets.push_back(entity);
 		}
 	}
-	throw std::runtime_error("No valid target found");
+	return targets;
 }

--- a/src/main/Implementation/Systems/CombatSystem.cpp
+++ b/src/main/Implementation/Systems/CombatSystem.cpp
@@ -214,6 +214,7 @@ BattleState CombatSystem::checkDeathCondition(EntityID defender, EntityID attack
 	bool playerIsDefending = defender == playerId;
 
 	if (healthDefender <= 0 && playerIsDefending) {
+		return BattleState::DEFEAT;
 	} else if (healthDefender <= 0 && playerIsAttacking) {
 		manager.addComponentToEntity<DeathComponent>(defender);
 	}

--- a/src/main/Implementation/Systems/CombatSystem.cpp
+++ b/src/main/Implementation/Systems/CombatSystem.cpp
@@ -302,17 +302,13 @@ int CombatSystem::getActionCost(BattleAction action)
 	}
 }
 
-bool CombatSystem::validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed,
-                                  int numberOfHealthPotions)
+bool CombatSystem::validateAction(BattleAction action, int AP, int numberOfUltimateAttacksUsed)
 {
 	int cost = getActionCost(action);
 	if (AP < cost) {
 		return false;
 	}
 	if (action == BattleAction::ULTIMATE_ATTACK && numberOfUltimateAttacksUsed >= 1) {
-		return false;
-	}
-	if (action == BattleAction::HEAL && numberOfHealthPotions <= 0) {
 		return false;
 	}
 	return true;

--- a/src/main/Implementation/Systems/CombatSystem.cpp
+++ b/src/main/Implementation/Systems/CombatSystem.cpp
@@ -7,6 +7,8 @@
 #include "Implementation/Components/BattleComponent.hpp"
 #include "Implementation/Components/StatsComponent.hpp"
 #include "Implementation/Components/WeaponComponent.hpp"
+#include <Abstract/Combat/Components/DeathComponent.hpp>
+#include <Abstract/Combat/Systems/BattleInputSystem.hpp>
 #include <Abstract/Overwordl/Components/InputComponent.hpp>
 #include <Abstract/Overwordl/Components/MovementComponent.hpp>
 #include <Abstract/Overwordl/Components/RenderComponent.hpp>
@@ -31,7 +33,7 @@ void CombatSystem::update()
 			if (player.has_value()) {
 				playerId = player.value();
 			}
-			EntityID currentAttacker = this->getAttacker(bmc.currentTurnIndex, bmc.participants);
+			EntityID currentAttacker = this->getAttacker(bmc);
 			BattleComponent &battle = manager.getComponent<BattleComponent>(currentAttacker);
 			if (bmc.isBattleOver) {
 				cleanUpBattle(battleId, currentAttacker, battle.battleState);
@@ -75,8 +77,7 @@ void CombatSystem::update()
 				break;
 			}
 			case BattleState::NEXT_ROUND:
-				bmc.currentTurnIndex++;
-				this->passTurn(currentAttacker, bmc.currentTurnIndex, bmc.participants);
+				this->passTurn(currentAttacker, bmc);
 				break;
 			case BattleState::VICTORY:
 				spdlog::get("combat")->info("Victory for player");
@@ -118,7 +119,7 @@ void CombatSystem::executeBattleAction(EntityID attacker, EntityID defender, Bat
 		auto weaponId = inventory.getEquippedItem(ITEM_TYPE::WEAPON);
 		auto attackerWeapon = manager.getComponent<WeaponComponent>(weaponId);
 		float damage = getDamageWithScaling(attackerStats, attackerWeapon, typeOfAction);
-		spdlog::get("combat")->info("Damage: {}", damage);
+		spdlog::get("combat")->info("Light Damage: {}", damage);
 		auto health = manager.getComponent<StatsComponent>(defender).health;
 		manager.getComponent<StatsComponent>(defender).health = std::max(0.0f, health - damage);
 		break;
@@ -130,6 +131,7 @@ void CombatSystem::executeBattleAction(EntityID attacker, EntityID defender, Bat
 		auto weaponId = inventory.getEquippedItem(ITEM_TYPE::WEAPON);
 		auto attackerWeapon = manager.getComponent<WeaponComponent>(weaponId);
 		float damage = getDamageWithScaling(attackerStats, attackerWeapon, typeOfAction);
+		spdlog::get("combat")->info("Heavy Damage: {}", damage);
 		auto health = manager.getComponent<StatsComponent>(defender).health;
 		manager.getComponent<StatsComponent>(defender).health = std::max(0.0f, health - damage);
 		break;
@@ -142,6 +144,7 @@ void CombatSystem::executeBattleAction(EntityID attacker, EntityID defender, Bat
 		auto weaponId = inventory.getEquippedItem(ITEM_TYPE::WEAPON);
 		auto attackerWeapon = manager.getComponent<WeaponComponent>(weaponId);
 		float damage = getDamageWithScaling(attackerStats, attackerWeapon, typeOfAction);
+		spdlog::get("combat")->info("Ultimate Damage: {}", damage);
 		auto health = manager.getComponent<StatsComponent>(defender).health;
 		manager.getComponent<StatsComponent>(defender).health = std::max(0.0f, health - damage);
 		manager.getComponent<BattleComponent>(attacker).numberOfUltimateAttacksUsed += 1;
@@ -199,34 +202,61 @@ bool CombatSystem::handleActionDelay(BattleComponent &battle)
 BattleState CombatSystem::checkDeathCondition(EntityID defender, EntityID attacker)
 {
 	float healthDefender = manager.getComponent<StatsComponent>(defender).health;
+	if (healthDefender > 0.0) {
+		return BattleState::NEXT_ROUND;
+	}
 	auto player = WorldUtils::getPlayer(manager);
 	EntityID playerId;
 	if (player.has_value()) {
 		playerId = player.value();
 	}
 	bool playerIsAttacking = attacker == playerId;
+	bool playerIsDefending = defender == playerId;
 
-	if (healthDefender <= 0) {
-		return playerIsAttacking ? BattleState::VICTORY : BattleState::DEFEAT;
+	if (healthDefender <= 0 && playerIsDefending) {
+	} else if (healthDefender <= 0 && playerIsAttacking) {
+		manager.addComponentToEntity<DeathComponent>(defender);
 	}
+	auto &attackerBattleComp = manager.getComponent<BattleComponent>(attacker);
 
+	std::vector<EntityID> aliveEnemies =
+	    BattleInputSystem::getTargetsInBattle(playerId, attackerBattleComp.battleManagerId, this->manager);
+
+	if (aliveEnemies.empty()) {
+		return BattleState::VICTORY;
+	}
 	return BattleState::NEXT_ROUND;
 }
-void CombatSystem::passTurn(EntityID &currentEntity, int currentTurnIndex, const std::vector<EntityID> participants)
+void CombatSystem::passTurn(EntityID &currentEntity, BattleManagerComponent &bmc)
 {
 
 	manager.getComponent<BattleComponent>(currentEntity).isActiveTurn = false;
-	EntityID nextId = this->getAttacker(currentTurnIndex, participants);
+	bmc.currentTurnIndex++;
+	EntityID nextId = this->getAttacker(bmc);
 	auto &nextBattleComponent = manager.getComponent<BattleComponent>(nextId);
 	nextBattleComponent.battleState = BattleState::TURN_START;
 	nextBattleComponent.isActiveTurn = true;
 }
-EntityID CombatSystem::getAttacker(int currentTurnIndex, const std::vector<EntityID> participants)
+EntityID CombatSystem::getAttacker(BattleManagerComponent &bmc)
 {
-	if (participants.size() == 0) {
+	if (bmc.participants.size() == 0) {
 		throw std::runtime_error("No participants in battle");
 	}
-	return participants[currentTurnIndex % participants.size()];
+	int numberOfParticipants = bmc.participants.size();
+	auto attacker = bmc.participants[bmc.currentTurnIndex % numberOfParticipants];
+	if (!manager.hasComponent<DeathComponent>(attacker)) {
+		return attacker;
+	}
+	int loopSafeguard = 0;
+	while (manager.hasComponent<DeathComponent>(attacker)) {
+		bmc.currentTurnIndex++;
+		loopSafeguard++;
+		if (loopSafeguard > numberOfParticipants) {
+			throw std::runtime_error("All participants are dead, but battle is not over");
+		}
+		attacker = bmc.participants[bmc.currentTurnIndex % numberOfParticipants];
+	}
+	return attacker;
 }
 void CombatSystem::cleanUpBattle(EntityID battleManagerId, EntityID winningEntity, BattleState battleState)
 {

--- a/src/main/Implementation/Systems/CombatSystem.cpp
+++ b/src/main/Implementation/Systems/CombatSystem.cpp
@@ -1,9 +1,11 @@
 #include "Abstract/Combat/Systems/CombatSystem.hpp"
 #include "Abstract/Combat/Components/BattleManagerComponent.hpp"
+#include "Abstract/Combat/Components/CombatGodMode.hpp"
 #include "Abstract/ECS/Entity/EntityID.hpp"
 #include "Abstract/ECS/System/System.hpp"
 #include "Abstract/Overwordl/Components/InventoryComponent.hpp"
 #include "Abstract/Overwordl/Components/ItemHealstatsComponent.hpp"
+#include "Abstract/Utils/GraveConfig.hpp"
 #include "Implementation/Components/BattleComponent.hpp"
 #include "Implementation/Components/StatsComponent.hpp"
 #include "Implementation/Components/WeaponComponent.hpp"
@@ -209,14 +211,24 @@ BattleState CombatSystem::checkDeathCondition(EntityID defender, EntityID attack
 	EntityID playerId;
 	if (player.has_value()) {
 		playerId = player.value();
+	} else {
+		throw std::runtime_error("No player found in checkDeathCondition");
 	}
 	bool playerIsAttacking = attacker == playerId;
 	bool playerIsDefending = defender == playerId;
 
 	if (healthDefender <= 0 && playerIsDefending) {
+		if (manager.hasComponent<CombatGodMode>(playerId)) {
+			manager.getComponent<StatsComponent>(defender).health = 100;
+			spdlog::get("combat")->info("Healing player back to 100, because of god mode");
+			return BattleState::NEXT_ROUND;
+		}
 		return BattleState::DEFEAT;
 	} else if (healthDefender <= 0 && playerIsAttacking) {
 		manager.addComponentToEntity<DeathComponent>(defender);
+		auto &dc = manager.getComponent<DeathComponent>(defender);
+		dc.graveTile = GraveConfig::defaultTile;
+		dc.graveTilesetPath = GraveConfig::tilesetPath;
 	}
 	auto &attackerBattleComp = manager.getComponent<BattleComponent>(attacker);
 

--- a/src/main/Implementation/Systems/EnemyHealthBarSystem.cpp
+++ b/src/main/Implementation/Systems/EnemyHealthBarSystem.cpp
@@ -74,8 +74,8 @@ void EnemyHealthBarSystem::createEnemyBar(EntityID id)
 void EnemyHealthBarSystem::updateEnemyBar(EntityID id, float hp, float maxHp, sf::Vector2f screenPos)
 {
 	if (hp > maxHp) {
-		spdlog::get("combat")->info("In healthbar-system health {} is bigger than maxHp {} for entity {}", hp, maxHp,
-		                            id.getId());
+		spdlog::get("combat")->debug("In healthbar-system health {} is bigger than maxHp {} for entity {}", hp, maxHp,
+		                             id.getId());
 	}
 	auto &bar = enemyBars[id];
 	bar->setMaximum(maxHp);

--- a/src/main/Implementation/Systems/EnemyHealthBarSystem.cpp
+++ b/src/main/Implementation/Systems/EnemyHealthBarSystem.cpp
@@ -5,6 +5,7 @@
 #include "Abstract/Utils/WorldUtlis.hpp"
 #include "Implementation/Components/BattleComponent.hpp"
 #include "Implementation/Components/StatsComponent.hpp"
+#include <Abstract/Combat/Components/DeathComponent.hpp>
 #include <spdlog/spdlog.h>
 
 EnemyHealthBarSystem::EnemyHealthBarSystem(ArchetypeManager &manager, tgui::Gui &gui, sf::RenderWindow &window)
@@ -38,6 +39,9 @@ void EnemyHealthBarSystem::update()
 				continue;
 			}
 
+			if (manager.hasComponent<DeathComponent>(id)) {
+				continue;
+			}
 			activeEnemies.push_back(id);
 
 			auto &stats = manager.getComponent<StatsComponent>(id);

--- a/src/main/Implementation/Systems/EnemyHealthBarSystem.cpp
+++ b/src/main/Implementation/Systems/EnemyHealthBarSystem.cpp
@@ -14,19 +14,25 @@ EnemyHealthBarSystem::EnemyHealthBarSystem(ArchetypeManager &manager, tgui::Gui 
 
 void EnemyHealthBarSystem::update()
 {
-	auto view = manager.view<BattleManagerComponent>();
+	bool battleIsActive = false;
+	manager.view<BattleManagerComponent>().each([&](EntityID id, auto &bmc) { battleIsActive = true; });
 
-	if (view.archetypes.size() == 0) {
+	if (!battleIsActive) {
 		clearAllBars();
 		return;
 	}
 
-	std::vector<EntityID> activeEnemies;
 	auto playerId = WorldUtils::getPlayer(manager);
 	if (!playerId.has_value()) {
 		throw std::runtime_error("Player entity not found in EnemyHealthBarSystem");
 	}
-	view.each([&](EntityID bmcId, BattleManagerComponent &bmc) {
+	std::vector<EntityID> activeEnemies;
+	if (!manager.hasComponent<BattleComponent>(playerId.value())) {
+		clearAllBars();
+		return;
+	}
+	std::optional<EntityID> hoveringTargetOpt = manager.getComponent<BattleComponent>(playerId.value()).hoveringTarget;
+	manager.view<BattleManagerComponent>().each([&](EntityID bmcId, BattleManagerComponent &bmc) {
 		for (EntityID id : bmc.participants) {
 			if (id == playerId.value()) {
 				continue;
@@ -37,14 +43,14 @@ void EnemyHealthBarSystem::update()
 			auto &stats = manager.getComponent<StatsComponent>(id);
 			auto &transform = manager.getComponent<TransformComponent>(id);
 
-			// Handle Coordinate Projection
 			sf::Vector2i pixelPos = window.mapCoordsToPixel(transform.position);
 			sf::Vector2f screenPos = sf::Vector2f(pixelPos);
 
 			if (!enemyBars.contains(id)) {
 				createEnemyBar(id);
 			}
-			updateEnemyBar(id, stats.health, stats.getStat(STATS::MAX_HEALTH), screenPos);
+			bool isHoveringTarget = hoveringTargetOpt.has_value() && (hoveringTargetOpt.value() == id);
+			updateEnemyBar(id, stats.health, stats.getStat(STATS::MAX_HEALTH), screenPos, isHoveringTarget);
 		}
 	});
 
@@ -66,12 +72,15 @@ void EnemyHealthBarSystem::createEnemyBar(EntityID id)
 	bar->getRenderer()->setFillColor(sf::Color::Red);
 	bar->getRenderer()->setBackgroundColor(sf::Color::White);
 	bar->setText("");
+	bar->getRenderer()->setBorders({1, 1, 1, 1});
+	bar->getRenderer()->setBorderColor(sf::Color::Black);
 
 	gui.add(bar);
 	enemyBars[id] = bar;
 }
 
-void EnemyHealthBarSystem::updateEnemyBar(EntityID id, float hp, float maxHp, sf::Vector2f screenPos)
+void EnemyHealthBarSystem::updateEnemyBar(EntityID id, float hp, float maxHp, sf::Vector2f screenPos,
+                                          bool isHoveringTarget)
 {
 	if (hp > maxHp) {
 		spdlog::get("combat")->debug("In healthbar-system health {} is bigger than maxHp {} for entity {}", hp, maxHp,
@@ -82,6 +91,13 @@ void EnemyHealthBarSystem::updateEnemyBar(EntityID id, float hp, float maxHp, sf
 	bar->setValue(hp);
 	bar->setPosition(screenPos.x - (bar->getSize().x / 2.0f), screenPos.y - 40.0f);
 	bar->setVisible(true);
+	if (isHoveringTarget) {
+		bar->getRenderer()->setBorders({2, 2, 2, 2});
+		bar->getRenderer()->setBorderColor(sf::Color::Yellow);
+	} else {
+		bar->getRenderer()->setBorders({1, 1, 1, 1});
+		bar->getRenderer()->setBorderColor(sf::Color::Black);
+	}
 }
 
 void EnemyHealthBarSystem::clearAllBars()

--- a/src/test/Implementation/Systems/AISystemTest.cpp
+++ b/src/test/Implementation/Systems/AISystemTest.cpp
@@ -13,7 +13,7 @@ TEST(AISystemTest, executeAILogicHeavyAttack)
 	ArchetypeManager manager = ArchetypeManager();
 	AISystem aiSystem = AISystem(manager);
 	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
-	EntityID player = manager.createEntity();
+	EntityID player = manager.createEntity<PlayerComponent>();
 	EntityID enemy = manager.createEntity();
 	EntityID battle = manager.createEntity();
 
@@ -40,7 +40,7 @@ TEST(AISystemTest, executeAILogicLightAttack)
 	ArchetypeManager manager = ArchetypeManager();
 	AISystem aiSystem = AISystem(manager);
 	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
-	EntityID player = manager.createEntity();
+	EntityID player = manager.createEntity<PlayerComponent>();
 	EntityID enemy = manager.createEntity();
 	EntityID battle = manager.createEntity();
 
@@ -67,7 +67,7 @@ TEST(AISystemTest, executeAILogicHeal)
 	ArchetypeManager manager = ArchetypeManager();
 	AISystem aiSystem = AISystem(manager);
 	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
-	EntityID player = manager.createEntity();
+	EntityID player = manager.createEntity<PlayerComponent>();
 	EntityID enemy = manager.createEntity();
 	EntityID battle = manager.createEntity();
 
@@ -98,7 +98,7 @@ TEST(AISystemTest, executeAILogicRest)
 	ArchetypeManager manager = ArchetypeManager();
 	AISystem aiSystem = AISystem(manager);
 	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
-	EntityID player = manager.createEntity();
+	EntityID player = manager.createEntity<PlayerComponent>();
 	EntityID enemy = manager.createEntity();
 	EntityID battle = manager.createEntity();
 
@@ -126,7 +126,7 @@ TEST(AISystemTest, executeAILogicUltimateAttack)
 	ArchetypeManager manager = ArchetypeManager();
 	AISystem aiSystem = AISystem(manager);
 	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
-	EntityID player = manager.createEntity();
+	EntityID player = manager.createEntity<PlayerComponent>();
 	EntityID enemy = manager.createEntity();
 	EntityID battle = manager.createEntity();
 
@@ -147,4 +147,19 @@ TEST(AISystemTest, executeAILogicUltimateAttack)
 	aiSystem.executeAILogic(enemy, {player, enemy});
 	EXPECT_EQ(BattleState::SELECTED_ACTION, manager.getComponent<BattleComponent>(enemy).battleState);
 	EXPECT_EQ(BattleAction::ULTIMATE_ATTACK, manager.getComponent<BattleComponent>(enemy).selectedAction);
+}
+
+TEST(AISystemTest, selectTargetWithMultipleEnemies)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+	EntityID player = manager.createEntity<PlayerComponent>();
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity();
+
+	auto target = aiSystem.selectTarget(enemy, {player, enemy, enemy2});
+	EXPECT_EQ(target.has_value(), true);
+	EXPECT_EQ(player, target.value());
 }

--- a/src/test/Implementation/Systems/CombatSystemTest.cpp
+++ b/src/test/Implementation/Systems/CombatSystemTest.cpp
@@ -3,6 +3,7 @@
 #include "Abstract/Combat/Systems/BattleInputSystem.hpp"
 #include "Abstract/ECS/ECSManager.hpp"
 #include "Abstract/Overwordl/Components/InventoryComponent.hpp"
+#include <Abstract/Combat/Components/DeathComponent.hpp>
 #include <Abstract/Overwordl/Components/ItemHealstatsComponent.hpp>
 #include <Abstract/Overwordl/Components/PartOfLayerComponent.hpp>
 #include <Abstract/Overwordl/Components/Player_Component.hpp>
@@ -751,4 +752,368 @@ TEST(CombatSystemTest, combatSystemEnemyWon)
 	EXPECT_EQ(0, manager.getComponent<StatsComponent>(enemy).numberOfFightsWon);
 
 	EXPECT_EQ(0, manager.getComponent<StatsComponent>(player).numberOfFightsWon);
+}
+
+TEST(CombatSystemTest, checkDeathConditionPlayerLost)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE = manager.getComponent<StatsComponent>(enemy);
+	statsComponentP.health = 0;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto returnState = combatSystem.checkDeathCondition(player, enemy);
+	EXPECT_EQ(BattleState::DEFEAT, returnState);
+}
+
+TEST(CombatSystemTest, checkDeathConditionPlayerWon)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE2 = manager.getComponent<StatsComponent>(enemy2);
+	statsComponentP.health = 10;
+	statsComponentE2.health = 0;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy, enemy2};
+	manager.addComponentToEntity<DeathComponent>(enemy);
+	auto returnState = combatSystem.checkDeathCondition(enemy2, player);
+	EXPECT_EQ(BattleState::VICTORY, returnState);
+}
+
+TEST(CombatSystemTest, checkDeathConditionNextRound)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE2 = manager.getComponent<StatsComponent>(enemy2);
+	statsComponentP.health = 10;
+	statsComponentE2.health = 20;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy, enemy2};
+	manager.addComponentToEntity<DeathComponent>(enemy);
+	auto returnState = combatSystem.checkDeathCondition(enemy2, player);
+	EXPECT_EQ(BattleState::NEXT_ROUND, returnState);
+}
+
+TEST(CombatSystemTest, getAttackerBaseCase)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE2 = manager.getComponent<StatsComponent>(enemy2);
+	statsComponentP.health = 10;
+	statsComponentE2.health = 20;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy, enemy2};
+	bmc.currentTurnIndex = 1;
+	manager.addComponentToEntity<DeathComponent>(enemy2);
+	auto nextTurnID = combatSystem.getAttacker(bmc);
+	EXPECT_EQ(enemy, nextTurnID);
+	EXPECT_EQ(1, bmc.currentTurnIndex);
+}
+
+TEST(CombatSystemTest, getAttackerSkipDeathEnemy)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE2 = manager.getComponent<StatsComponent>(enemy2);
+	statsComponentP.health = 10;
+	statsComponentE2.health = 20;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy, enemy2};
+	bmc.currentTurnIndex = 1;
+	manager.addComponentToEntity<DeathComponent>(enemy);
+	auto nextTurnID = combatSystem.getAttacker(bmc);
+	EXPECT_EQ(enemy2, nextTurnID);
+	EXPECT_EQ(2, bmc.currentTurnIndex);
+}
+
+TEST(CombatSystemTest, getAttackerCheckBoundaryCondition)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE2 = manager.getComponent<StatsComponent>(enemy2);
+	statsComponentP.health = 10;
+	statsComponentE2.health = 20;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy, enemy2};
+	bmc.currentTurnIndex = 1;
+	manager.addComponentToEntity<DeathComponent>(enemy);
+	manager.addComponentToEntity<DeathComponent>(enemy2);
+	manager.addComponentToEntity<DeathComponent>(player);
+	EXPECT_THROW(combatSystem.getAttacker(bmc), std::runtime_error);
+}
+
+TEST(CombatSystemTest, passTurnAllActiveParticipants)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE2 = manager.getComponent<StatsComponent>(enemy2);
+	statsComponentP.health = 10;
+	statsComponentE2.health = 20;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy, enemy2};
+	bmc.currentTurnIndex = 1;
+	combatSystem.passTurn(enemy, bmc);
+	EXPECT_EQ(2, bmc.currentTurnIndex);
+	EXPECT_EQ(false, manager.getComponent<BattleComponent>(enemy).isActiveTurn);
+	EXPECT_EQ(true, manager.getComponent<BattleComponent>(enemy2).isActiveTurn);
+	EXPECT_EQ(BattleState::TURN_START, manager.getComponent<BattleComponent>(enemy2).battleState);
+}
+
+TEST(CombatSystemTest, passTurnOneDeathParticipant)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID enemy2 = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent, TransformComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy2);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	auto &statsComponentE2 = manager.getComponent<StatsComponent>(enemy2);
+	statsComponentP.health = 10;
+	statsComponentE2.health = 20;
+
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	auto &battleComponentE2 = manager.getComponent<BattleComponent>(enemy2);
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	battleComponentE2.battleManagerId = battle;
+
+	auto &bmc = manager.getComponent<BattleManagerComponent>(battle);
+
+	manager.addComponentToEntity<DeathComponent>(enemy2);
+
+	bmc.participants = {player, enemy, enemy2};
+	bmc.currentTurnIndex = 1;
+	combatSystem.passTurn(enemy, bmc);
+	EXPECT_EQ(3, bmc.currentTurnIndex);
+	EXPECT_EQ(false, manager.getComponent<BattleComponent>(enemy).isActiveTurn);
+	EXPECT_EQ(false, manager.getComponent<BattleComponent>(enemy2).isActiveTurn);
+	EXPECT_EQ(true, manager.getComponent<BattleComponent>(player).isActiveTurn);
+	EXPECT_EQ(BattleState::TURN_START, manager.getComponent<BattleComponent>(player).battleState);
 }


### PR DESCRIPTION
Closing #40 

Changes:

- When enemy dies in combat, a grave replaces its sprite (hardcoded position on edited_tilesheet)
- Add a GodComponent, when this is added, this entity does recover damage after every round for free
- Multiple enemies can participated in the fight, with a hardcoded radius around the enemy with which the player has interacted
- Player must manually select enemy in the fight (with ->, <- and confirm with ENTER)