### PR TITLE
56 bug when selecting passive abilities first in combat

### DIFF
--- a/src/main/Implementation/Components/BattleComponent.hpp
+++ b/src/main/Implementation/Components/BattleComponent.hpp
@@ -22,7 +22,7 @@ struct BattleComponent : Component<BattleComponent> {
 	int numberOfUltimateAttacksUsed{0};
 	int numberOfHealsUsed{0};
 	BattleAction selectedAction;
-	EntityID target;
+	EntityID target{-1};
 	bool isPlayerTeam;
 	bool isActiveTurn = false;
 	BattleState battleState = BattleState::TURN_START;

--- a/src/main/Implementation/Systems/BattleInputSystem.cpp
+++ b/src/main/Implementation/Systems/BattleInputSystem.cpp
@@ -79,6 +79,7 @@ void BattleInputSystem::connectCallbacks()
 			auto &b = manager.getComponent<BattleComponent>(playerId);
 			b.selectedAction = BattleAction::HEAL;
 			b.battleState = BattleState::SELECTING_TARGET;
+			b.target = playerId;
 		}
 	});
 	ui.getButton("BtnRest")->onPress([this]() {
@@ -91,6 +92,7 @@ void BattleInputSystem::connectCallbacks()
 			auto &b = manager.getComponent<BattleComponent>(playerId);
 			b.selectedAction = BattleAction::REST;
 			b.battleState = BattleState::SELECTING_TARGET;
+			b.target = playerId;
 		}
 	});
 }

--- a/src/main/Implementation/Systems/CombatSystem.cpp
+++ b/src/main/Implementation/Systems/CombatSystem.cpp
@@ -176,12 +176,25 @@ void CombatSystem::executeBattleAction(EntityID attacker, EntityID defender, Bat
 		break;
 	}
 	}
-	spdlog::get("combat")->info("Entity {} attacks Entity {} with {}!", attacker.getId(), defender.getId(),
-	                            static_cast<int>(typeOfAction));
-	spdlog::get("combat")->info("Entity {} has {} HP and {} AP left!", defender.getId(),
-	                            manager.getComponent<StatsComponent>(defender).health,
-	                            manager.getComponent<BattleComponent>(defender).AP);
-	spdlog::get("combat")->info("Entity {} has {} HP and {} AP left!", attacker.getId(),
+	if (defender == -1) {
+		throw std::runtime_error("Defender is not set for action execution");
+	}
+	bool isOffensive = (typeOfAction == BattleAction::LIGHT_ATTACK || typeOfAction == BattleAction::HEAVY_ATTACK
+	                    || typeOfAction == BattleAction::ULTIMATE_ATTACK);
+
+	if (isOffensive) {
+		spdlog::get("combat")->info("Entity {} attacks Entity {} with action {}!", attacker.getId(), defender.getId(),
+		                            static_cast<int>(typeOfAction));
+
+		spdlog::get("combat")->info("Defender Entity {} has {} HP and {} AP left!", defender.getId(),
+		                            manager.getComponent<StatsComponent>(defender).health,
+		                            manager.getComponent<BattleComponent>(defender).AP);
+	} else {
+		std::string actionName = (typeOfAction == BattleAction::HEAL) ? "heals" : "rests";
+		spdlog::get("combat")->info("Entity {} {}!", attacker.getId(), actionName);
+	}
+
+	spdlog::get("combat")->info("Attacker Entity {} has {} HP and {} AP left!", attacker.getId(),
 	                            manager.getComponent<StatsComponent>(attacker).health,
 	                            manager.getComponent<BattleComponent>(attacker).AP);
 }

--- a/src/test/Implementation/Systems/CombatSystemTest.cpp
+++ b/src/test/Implementation/Systems/CombatSystemTest.cpp
@@ -346,7 +346,7 @@ TEST(CombatSystemTest, initialFightingSetupOneRoundHealWithFullLife)
 
 	// Simulate BattletInputSystem
 	battleComponentP.selectedAction = BattleAction::HEAL;
-	battleComponentP.target = enemy;
+	battleComponentP.target = player;
 	battleComponentP.battleState = BattleState::SELECTED_ACTION;
 	//
 
@@ -1141,4 +1141,152 @@ TEST(CombatSystemTest, passTurnOneDeathParticipant)
 	EXPECT_EQ(false, manager.getComponent<BattleComponent>(enemy2).isActiveTurn);
 	EXPECT_EQ(true, manager.getComponent<BattleComponent>(player).isActiveTurn);
 	EXPECT_EQ(BattleState::TURN_START, manager.getComponent<BattleComponent>(player).battleState);
+}
+
+TEST(CombatSystemTest, initialFightingSetupOneRoundHealWithoutSettingTarget)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+	AudioManager audioManager = AudioManager();
+	AudioSystem audiosystem = AudioSystem(manager, audioManager);
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem, audiosystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	BattleManagerComponent &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy};
+	bmc.currentTurnIndex = 0;
+	bmc.isBattleOver = false;
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	combatSystem.update();
+
+	auto playerWeaponId = manager.createEntity<WeaponComponent>();
+	WeaponComponent &playerWeapon = manager.getComponent<WeaponComponent>(playerWeaponId);
+	playerWeapon.scalingFactor = WEAPON_SCALING_FACTOR::SCALE_C;
+	playerWeapon.weaponType = WeaponType::RANGE;
+
+	auto enemyWeaponId = manager.createEntity<WeaponComponent>();
+	WeaponComponent &enemyWeapon = manager.getComponent<WeaponComponent>(enemyWeaponId);
+	enemyWeapon.scalingFactor = WEAPON_SCALING_FACTOR::SCALE_B;
+	enemyWeapon.weaponType = WeaponType::RANGE;
+
+	auto &playerInventory = manager.getComponent<InventoryComponent>(player);
+	playerInventory.addItem(playerWeaponId, ITEM_TYPE::WEAPON);
+	playerInventory.equip(playerWeaponId, ITEM_TYPE::WEAPON);
+
+	auto &enemyInventory = manager.getComponent<InventoryComponent>(enemy);
+	enemyInventory.addItem(enemyWeaponId, ITEM_TYPE::WEAPON);
+	enemyInventory.equip(enemyWeaponId, ITEM_TYPE::WEAPON);
+
+	combatSystem.update();
+
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	statsComponentP.health = 100;
+	statsComponentP.stats[STATS::MAX_HEALTH] = 100;
+	auto &statsComponentE = manager.getComponent<StatsComponent>(enemy);
+	statsComponentE.health = 80;
+	auto &inventoryComponentP = manager.getComponent<InventoryComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	EXPECT_EQ(BattleState::WAITING_FOR_INPUT, battleComponentP.battleState);
+	EXPECT_EQ(true, battleComponentP.isActiveTurn);
+	EXPECT_EQ(false, battleComponentE.isActiveTurn);
+
+	// Simulate BattletInputSystem
+	battleComponentP.selectedAction = BattleAction::HEAL;
+	// No target set
+	battleComponentP.battleState = BattleState::SELECTED_ACTION;
+	//
+
+	EXPECT_THROW(combatSystem.update(), std::runtime_error);
+}
+
+TEST(CombatSystemTest, initialFightingSetupOneRoundRestWithoutSettingTarget)
+{
+	ArchetypeManager manager = ArchetypeManager();
+	AISystem aiSystem = AISystem(manager);
+	EntityID world = manager.createEntity<WorldComponent>();
+	EntityID player = manager.createEntity<PlayerComponent, PartOfLayerComponent>();
+	auto &playerLayer = manager.getComponent<PartOfLayerComponent>(player);
+	auto &worldLayer = manager.getComponent<WorldComponent>(world);
+
+	worldLayer.currentLayer = LAYERTYPE::OVERWORLD;
+	worldLayer.currentLevel = LEVEL_NAME::LEVEL1;
+
+	playerLayer.layer = LAYERTYPE::OVERWORLD;
+	playerLayer.level = LEVEL_NAME::LEVEL1;
+	AudioManager audioManager = AudioManager();
+	AudioSystem audiosystem = AudioSystem(manager, audioManager);
+	CombatSystem combatSystem = CombatSystem(manager, aiSystem, audiosystem);
+
+	EntityID enemy = manager.createEntity();
+	EntityID battle = manager.createEntity(EntityTag::BATTLEMANAGER);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(player);
+	manager.addComponentToEntity<BattleComponent, StatsComponent, InventoryComponent>(enemy);
+	manager.addComponentToEntity<BattleManagerComponent>(battle);
+	BattleManagerComponent &bmc = manager.getComponent<BattleManagerComponent>(battle);
+	bmc.participants = {player, enemy};
+	bmc.currentTurnIndex = 0;
+	bmc.isBattleOver = false;
+	auto &battleComponentP = manager.getComponent<BattleComponent>(player);
+	auto &battleComponentE = manager.getComponent<BattleComponent>(enemy);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	combatSystem.update();
+
+	auto playerWeaponId = manager.createEntity<WeaponComponent>();
+	WeaponComponent &playerWeapon = manager.getComponent<WeaponComponent>(playerWeaponId);
+	playerWeapon.scalingFactor = WEAPON_SCALING_FACTOR::SCALE_C;
+	playerWeapon.weaponType = WeaponType::RANGE;
+
+	auto enemyWeaponId = manager.createEntity<WeaponComponent>();
+	WeaponComponent &enemyWeapon = manager.getComponent<WeaponComponent>(enemyWeaponId);
+	enemyWeapon.scalingFactor = WEAPON_SCALING_FACTOR::SCALE_B;
+	enemyWeapon.weaponType = WeaponType::RANGE;
+
+	auto &playerInventory = manager.getComponent<InventoryComponent>(player);
+	playerInventory.addItem(playerWeaponId, ITEM_TYPE::WEAPON);
+	playerInventory.equip(playerWeaponId, ITEM_TYPE::WEAPON);
+
+	auto &enemyInventory = manager.getComponent<InventoryComponent>(enemy);
+	enemyInventory.addItem(enemyWeaponId, ITEM_TYPE::WEAPON);
+	enemyInventory.equip(enemyWeaponId, ITEM_TYPE::WEAPON);
+
+	combatSystem.update();
+
+	auto &statsComponentP = manager.getComponent<StatsComponent>(player);
+	statsComponentP.health = 100;
+	statsComponentP.stats[STATS::MAX_HEALTH] = 100;
+	auto &statsComponentE = manager.getComponent<StatsComponent>(enemy);
+	statsComponentE.health = 80;
+	auto &inventoryComponentP = manager.getComponent<InventoryComponent>(player);
+	battleComponentP.battleManagerId = battle;
+	battleComponentE.battleManagerId = battle;
+	EXPECT_EQ(BattleState::WAITING_FOR_INPUT, battleComponentP.battleState);
+	EXPECT_EQ(true, battleComponentP.isActiveTurn);
+	EXPECT_EQ(false, battleComponentE.isActiveTurn);
+
+	// Simulate BattletInputSystem
+	battleComponentP.selectedAction = BattleAction::REST;
+	// No target set
+	battleComponentP.battleState = BattleState::SELECTED_ACTION;
+	//
+
+	EXPECT_THROW(combatSystem.update(), std::runtime_error);
 }


### PR DESCRIPTION
Closes #56 
Did the following to fix the crash when selecting REST or HEAL as the first action in battle.

- BattleComponent: Set target to -1 as default
- BattleInpuSystem: Set target to player for REST and HEAL
- CombatSystem: Check for target_id equal to -1 and different logging dependent on battleAction
- Two tests to check if the error is thrown, if the target_id is -1