### PR TITLE
95 crash when switching layers with animationsystem

### DIFF
--- a/src/main/Abstract/Overwordl/Components/AnimationComponent.hpp
+++ b/src/main/Abstract/Overwordl/Components/AnimationComponent.hpp
@@ -32,7 +32,7 @@ class AnimationSequence {
 class AnimationComponent : public Component<AnimationComponent> {
   private:
 	std::unordered_map<ENTITY_ANIMATIONS_STATE, AnimationSequence> animations;
-	std::optional<int> currentAnimationEntityId = 0;
+	std::optional<int> currentAnimationEntityId = std::nullopt;
 	int framesElapsed{};
 
   public:
@@ -49,10 +49,7 @@ class AnimationComponent : public Component<AnimationComponent> {
 			int k = 0;
 			while (anims.getMember(std::to_string(k)) != nullptr) {
 				tson::TiledClass anim = anims.get<tson::TiledClass>(std::to_string(k));
-				Animation animation = {
-					anim.get<int>("entitySpriteId"),
-					anim.get<int>("numFrames")
-				};
+				Animation animation = {anim.get<int>("entitySpriteId"), anim.get<int>("numFrames")};
 				animSeq.push_back(animation);
 				k++;
 			}
@@ -78,7 +75,7 @@ class AnimationComponent : public Component<AnimationComponent> {
 		currentAnimationEntityId = anim.entityAnimationSpriteId;
 	}
 
-	std::optional<int>  getCurrentAnimation() const { return currentAnimationEntityId; }
+	std::optional<int> getCurrentAnimation() const { return currentAnimationEntityId; }
 	void addAnimation(ENTITY_ANIMATIONS_STATE state, const AnimationSequence &animation_sequence)
 	{
 		this->animations[state] = animation_sequence;

--- a/src/main/Implementation/Overworld/AnimationSetterSystem.cpp
+++ b/src/main/Implementation/Overworld/AnimationSetterSystem.cpp
@@ -69,9 +69,21 @@ void AnimationSetterSystem::update()
 			    return;
 		    }
 
+		    if (!manager.hasComponent<SpriteComponent>(
+		            EntityID::fromExistingId(component.getCurrentAnimation().value()))) {
+			    spdlog::warn("AnimationSetterSystem: Current animation entity {} does not have a SpriteComponent!",
+			                 component.getCurrentAnimation().value());
+			    return;
+		    }
 		    auto &animSprite = manager.getComponent<SpriteComponent>(component.getCurrentAnimation().value());
 		    sprite.tilesetPath = animSprite.tilesetPath;
 		    sprite.tileInfo = animSprite.tileInfo;
+		    if (!manager.hasComponent<TransformComponent>(
+		            EntityID::fromExistingId(component.getCurrentAnimation().value()))) {
+			    spdlog::warn("AnimationSetterSystem: Current animation entity {} does not have a TransformComponent!",
+			                 component.getCurrentAnimation().value());
+			    return;
+		    }
 		    auto &comp = manager.getComponent<TransformComponent>(component.getCurrentAnimation().value());
 		    tcomp.rotation = comp.rotation;
 		    tcomp.scale = comp.scale;

--- a/src/ressources/TileMapEditorOutput/filledWithEnums/properties.json
+++ b/src/ressources/TileMapEditorOutput/filledWithEnums/properties.json
@@ -560,7 +560,8 @@
             "PICK_ITEM",
             "DOOR_INTERACTION",
             "SWITCH_LAYER",
-            "START_BATTLE"
+            "START_BATTLE",
+            "BONFIRE_REST"
         ],
         "valuesAsFlags": false
     },


### PR DESCRIPTION
Closing #95 

The problem seems to be that the currentAnimationEntityId in AnimationComponent was initialized to 0, so when calling hasValue(), it always returned true and thus returned 0.